### PR TITLE
Design changes to Filter & Details page

### DIFF
--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -32,7 +32,7 @@
       <div class="col-xs-12 sticky" data-spy="affix" data-offset-top="300">
         <div class="btn-group">
           <a class="btn btn-primary openInJOSM" target="_blank" href="{{ changeset.josm_link }}">
-            {% trans 'Open in JOSM' %}
+            {% trans 'Open in <u>J</u>OSM' %}
           </a>
           <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>
@@ -43,7 +43,7 @@
           </ul>
         </div>
         <a class="btn btn-primary openHdyc" target="_blank" href="http://hdyc.neis-one.org/?{{ changeset.user }}">
-          {% trans 'HDYC' %}
+          {% trans '<u>H</u>DYC' %}
         </a>
         {% if changeset.checked %}
         {% if changeset.check_user == request.user %}
@@ -72,7 +72,7 @@
             <li>
             <form action="{% url 'changeset:set_good' changeset.pk %}" method="post">{% csrf_token %}
             <button class="markGood" type="submit">
-              <span class="glyphicon glyphicon-thumbs-up"></span> {% trans 'Mark as verified and not harmful' %}
+              <span class="glyphicon glyphicon-thumbs-up"></span> {% trans 'Mark as verified and not harmful (<u>G</u>)' %}
             </button>
             </form>
           </li>
@@ -80,7 +80,7 @@
             <form action="{% url 'changeset:set_harmful' changeset.pk %}" method="post">{% csrf_token %}
             <button class="markBad" type="submit">
             <span class="glyphicon glyphicon-thumbs-down"></span>
-            {% trans 'Mark as verified and harmful' %}
+            {% trans 'Mark as verified and harmful (<u>B</u>)' %}
             </button>
             </form>
         </li>
@@ -259,7 +259,7 @@
     $(window).on('keypress', function(e) {
       var key = e.keyCode || e.charCode;
       if (key === 106) {
-        // key j for JSOSM
+        // key j for JOSM
         $('.openInJOSM').click();
       } else if (key === 104) {
         // key h for open HDYC
@@ -268,13 +268,13 @@
         // key o for open in OSM
         $('.openOSM')[0].click();
       } else if (key === 103) {
-        // mark as good
+        // key g to mark as good
         $('.markGood')[0].click();
       } else if (key === 98) {
-        // mark as bad
+        // key b to mark as bad
         $('.markBad')[0].click();
       } else if (key === 117) {
-        // undo marking
+        // key u to undo marking
         $('.undoMarking').click();
       }
     });

--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -11,9 +11,9 @@
     <div class="row">
       <div class="col-md-12">
         <h3>
-          <span class="label label-success">{{ changeset.create }}</span>
-          <span class="label label-warning">{{ changeset.modify }}</span>
-          <span class="label label-danger">{{ changeset.delete }}</span>
+          <span class="label label-success" title="Total features added">{{ changeset.create }}</span>
+          <span class="label label-warning" title="Total features modified">{{ changeset.modify }}</span>
+          <span class="label label-danger" title="Total features removed">{{ changeset.delete }}</span>
         </h3>
       </div>
     </div>
@@ -72,7 +72,7 @@
             <li>
             <form action="{% url 'changeset:set_good' changeset.pk %}" method="post">{% csrf_token %}
             <button class="markGood" type="submit">
-              <span class="glyphicon glyphicon-thumbs-up"></span> {% trans 'Mark as verified and not harmful (<u>G</u>)' %}
+              <span class="glyphicon glyphicon-thumbs-up"></span> {% trans 'Verify as not harmful (<u>G</u>ood)' %}
             </button>
             </form>
           </li>
@@ -80,7 +80,7 @@
             <form action="{% url 'changeset:set_harmful' changeset.pk %}" method="post">{% csrf_token %}
             <button class="markBad" type="submit">
             <span class="glyphicon glyphicon-thumbs-down"></span>
-            {% trans 'Mark as verified and harmful (<u>B</u>)' %}
+            {% trans 'Verify as harmful (<u>B</u>ad)' %}
             </button>
             </form>
         </li>

--- a/osmchadjango/changeset/templates/changeset/changeset_list.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_list.html
@@ -21,7 +21,7 @@
     <form action="." id="filtersForm" method="GET" class="form-horizontal">
 
       <div class="form-group">
-        <label for="date__gte" class="col-sm-2 control-label">From</label>
+        <label for="date__gte" class="col-sm-2 control-label">From:</label>
         <div class="col-sm-3">
           <div class="input-group">
             <input class="form-control" id="date__gte" name="date__gte" type="date" value="{{ get.date__gte }}" />
@@ -35,58 +35,58 @@
             </div><!-- /btn-group -->
           </div><!-- /input-group -->
         </div>
-        <label for="date__lte" class="col-sm-2 control-label">To</label>
+        <label for="date__lte" class="col-sm-2 control-label">To:</label>
         <div class="col-sm-3">
           <input class="form-control" id="date__lte" name="date__lte" type="date" value="{{ get.date__lte }}"/>
         </div>
       </div>
 
       <div class="form-group">
-        <label for="create__gte" class="col-sm-2 control-label">Min. Additions</label>
+        <label for="create__gte" class="col-sm-2 control-label">Min. Additions:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Minimum number of features added in a changeset" name="create__gte" placeholder="50" value="{{ get.create__gte }}"/>
         </div>
-        <label for="create__lte" class="col-sm-2 control-label">Max. Additions</label>
+        <label for="create__lte" class="col-sm-2 control-label">Max. Additions:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Maximum number of features added in a changeset" name="create__lte" placeholder="100" value="{{ get.create__lte }}"/>
         </div>
       </div>
 
       <div class="form-group">
-        <label for="modify__gte" class="col-sm-2 control-label">Min. Modifications</label>
+        <label for="modify__gte" class="col-sm-2 control-label">Min. Modifications:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Minimum number of features modified in a changeset" name="modify__gte" placeholder="10" value="{{ get.modify__gte }}"/>
         </div>
-        <label for="modify__lte" class="col-sm-2 control-label">Max. Modifications</label>
+        <label for="modify__lte" class="col-sm-2 control-label">Max. Modifications:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Maximum number of features modified in a changeset" name="modify__lte" placeholder="20" value="{{ get.modify__lte }}"/>
         </div>
       </div>
 
       <div class="form-group">
-        <label for="delete__gte" class="col-sm-2 control-label">Min. Deletions</label>
+        <label for="delete__gte" class="col-sm-2 control-label">Min. Deletions:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Minimum number of features deleted in a changeset" name="delete__gte" placeholder="40" value="{{ get.delete__gte }}" />
         </div>
-        <label for="delete__lte" class="col-sm-2 control-label">Max. Deletions</label>
+        <label for="delete__lte" class="col-sm-2 control-label">Max. Deletions:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Maximum number of features deleted in a changeset" name="delete__lte" placeholder="80" value="{{ get.delete__lte }}" />
         </div>
       </div>
 
       <div class="form-group">
-        <label for="editor__icontains" class="col-sm-2 control-label">Editor</label>
+        <label for="editor__icontains" class="col-sm-2 control-label">Editor:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Editor used to create the changeset" name="editor__icontains" placeholder="JOSM" value="{{ get.editor__icontains }}" />
         </div>
-        <label class="col-sm-2 control-label" for="username">Users</label>
+        <label class="col-sm-2 control-label" for="username">Users:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Filter by OSM Usernames" name="usernames" placeholder="paul10, iak8" value="{{ get.usernames }}" />
         </div>
       </div>
 
       <div class="form-group">
-       <label class="col-sm-2 control-label" for="comment__icontains">Comment</label>
+       <label class="col-sm-2 control-label" for="comment__icontains">Comment:</label>
        <div class="col-sm-3">
          <input class="form-control" name="comment__icontains" value="{{ get.comment__icontains }}" />
        </div>
@@ -99,7 +99,7 @@
       </div>
 
       <div class="form-group">
-        <label class="col-sm-2 control-label" for="bbox">BBox</label>
+        <label class="col-sm-2 control-label" for="bbox">BBox:</label>
         <div class="col-sm-3">
           <div class="input-group">
             <input class="form-control" data-toggle="tooltip" title="sw long., sw lat., ne long., ne lat. coordinates" name="bbox" id="bbox" placeholder="46.70,20.87,68.38,31.14" value="{{ get.bbox }}" />
@@ -111,7 +111,7 @@
       </div>
 
       <div class="form-group">
-        <label for="is_suspect" class="col-sm-2 control-label">Show changesets</label>
+        <label for="is_suspect" class="col-sm-2 control-label">Show changesets:</label>
         <div class="col-sm-3">
           <label class="radio-inline">
             <input name="is_suspect" type="radio" value="True" {% if get.is_suspect == 'True' %} checked {% endif %} />
@@ -169,7 +169,7 @@
       </div>
 
       <div class="form-group">
-        <label for="reasons" class="col-sm-2 control-label">Reason</label>
+        <label for="reasons" class="col-sm-2 control-label">Reason:</label>
         <div class="col-sm-3">
           <select class="form-control" name="reasons">
             <option value="">---------</option>
@@ -180,7 +180,7 @@
             {% endfor %}
           </select>
         </div>
-        <label for="sort" class="col-sm-2 control-label">Sort</label>
+        <label for="sort" class="col-sm-2 control-label">Sort:</label>
         <div class="col-sm-3">
           <select class="form-control" name="sort">
             <option value="">---------</option>

--- a/osmchadjango/feature/templates/feature/feature_list.html
+++ b/osmchadjango/feature/templates/feature/feature_list.html
@@ -18,7 +18,7 @@
     <form action="./features" id="filtersForm" method="GET" class="form-horizontal">
 
       <div class="form-group">
-        <label for="changeset__date__gte" class="col-sm-2 control-label">From</label>
+        <label for="changeset__date__gte" class="col-sm-2 control-label">From:</label>
         <div class="col-sm-3">
           <div class="input-group">
             <input class="form-control" id="changeset__date__gte" name="changeset__date__gte" type="date" value="{{ get.changeset__date__gte }}" />
@@ -32,14 +32,14 @@
             </div><!-- /btn-group -->
           </div><!-- /input-group -->
         </div>
-        <label for="changeset__date__lte" class="col-sm-2 control-label">To</label>
+        <label for="changeset__date__lte" class="col-sm-2 control-label">To:</label>
         <div class="col-sm-3">
           <input class="form-control" id="changeset__date__lte" name="changeset__date__lte" type="date" value="{{ get.changeset__date__lte }}"/>
         </div>
       </div>
 
       <div class="form-group">
-        <label for="changeset__editor__icontains" class="col-sm-2 control-label">Editor</label>
+        <label for="changeset__editor__icontains" class="col-sm-2 control-label">Editor:</label>
         <div class="col-sm-3">
           <input data-toggle="tooltip" title="Editor used to create the changeset" class="form-control" name="changeset__editor__icontains" placeholder="JOSM" value="{{ get.changeset__editor__icontains }}" />
         </div>
@@ -50,11 +50,11 @@
       </div>
 
       <div class="form-group">
-        <label for="osm_version__gte" class="col-sm-2 control-label">Min. Version</label>
+        <label for="osm_version__gte" class="col-sm-2 control-label">Min. Version:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Minimum version of a feature" name="osm_version__gte" placeholder="10" value="{{ get.osm_version__gte }}"/>
         </div>
-        <label for="osm_version__lte" class="col-sm-2 control-label">Max. Version</label>
+        <label for="osm_version__lte" class="col-sm-2 control-label">Max. Version:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="Maximum version of a feature" name="osm_version__lte" placeholder="60" value="{{ get.osm_version__lte }}"/>
         </div>
@@ -90,7 +90,7 @@
       </div>
 
       <div class="form-group">
-        <label for="reasons" class="col-sm-2 control-label">Reason</label>
+        <label for="reasons" class="col-sm-2 control-label">Reason:</label>
         <div class="col-sm-3">
           <select class="form-control" name="reasons">
             <option value="">---------</option>
@@ -101,7 +101,7 @@
             {% endfor %}
           </select>
         </div>
-        <label class="col-sm-2 control-label" for="bbox">BBox</label>
+        <label class="col-sm-2 control-label" for="bbox">BBox:</label>
         <div class="col-sm-3">
           <input class="form-control" data-toggle="tooltip" title="sw long., sw lat., ne long., ne lat. coordinates" name="bbox" placeholder="46.70,20.87,68.38,31.14" value="{{ get.bbox }}" />
         </div>

--- a/osmchadjango/static/css/project.css
+++ b/osmchadjango/static/css/project.css
@@ -35,6 +35,9 @@
 
 #filters {
   display: none;
+  padding-bottom: 0.5em;
+  border-bottom: 2px solid #ddd;
+  margin-bottom: 0.25em;
 }
 
 td, th {
@@ -64,12 +67,19 @@ td, th {
 }
 
 .sticky.affix {
-  background: #fff;
+  background: rgba(255,255,255,0.9);
   border-bottom: 1px #ccc solid;
 }
 
 .sticky .dropdown-menu {
   padding: 0;
+  min-width: 220px;
+}
+
+.sticky .dropdown-menu button{
+  padding: 10px;
+  width: 220px;
+  text-align: left;
 }
 
 .list-group {
@@ -93,6 +103,14 @@ td, th {
   border: none;
   background-color: transparent;
   border-bottom: 1px solid #ddd;
+}
+
+.text-pagination {
+  text-align: center;
+}
+
+#map {
+  margin: 0.5em 0;
 }
 
 .footer {

--- a/osmchadjango/static/css/project.css
+++ b/osmchadjango/static/css/project.css
@@ -58,8 +58,18 @@ td, th {
 .sticky {
   z-index: 1000;
   top: 0;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin:0;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.sticky.affix {
+  background: #fff;
+  border-bottom: 1px #ccc solid;
+}
+
+.sticky .dropdown-menu {
+  padding: 0;
 }
 
 .list-group {
@@ -83,4 +93,8 @@ td, th {
   border: none;
   background-color: transparent;
   border-bottom: 1px solid #ddd;
+}
+
+.footer {
+  text-align: center;
 }


### PR DESCRIPTION
**Ready to be merged**

- [x] Sticky buttons now have a white background (after scrolling)
- [x] Buttons with keyboard shortcuts have the character <u>u</u>nderlined
- [x] Keycodes in js have their key added as a comment
- [x] Footer is now center-aligned to not conflict with the `Open in new window` link from the changeset map
- [x] Consistent labels in Filter page
- [x] Minor tweaks in the spacing around the layout
- [ ] Get feedback on type hierarchy & layout and make any more changes