### PR TITLE
handle redirect to login when marking good / bad when user is not log…

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -219,7 +219,7 @@ ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 # Select the correct user model
 AUTH_USER_MODEL = 'users.User'
 LOGIN_REDIRECT_URL = 'users:redirect'
-LOGIN_URL = '/social/login/openstreetmap'
+LOGIN_URL = '/social/login/openstreetmap/'
 
 # SLUGLIFIER
 AUTOSLUG_SLUGIFY_FUNCTION = 'slugify.slugify'

--- a/osmchadjango/changeset/views.py
+++ b/osmchadjango/changeset/views.py
@@ -148,6 +148,10 @@ class ChangesetDetailView(DetailView):
 class SetHarmfulChangeset(SingleObjectMixin, View):
     model = Changeset
 
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return HttpResponseRedirect(reverse('changeset:detail', args=[self.object.pk]))
+
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         if self.object.uid not in [i.uid for i in request.user.social_auth.all()]:
@@ -163,6 +167,10 @@ class SetHarmfulChangeset(SingleObjectMixin, View):
 
 class SetGoodChangeset(SingleObjectMixin, View):
     model = Changeset
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return HttpResponseRedirect(reverse('changeset:detail', args=[self.object.pk]))
 
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()


### PR DESCRIPTION
This PR handles the login redirect flow when a user marks a changeset as good bad when not logged in.

There were a couple of things to fix:

 - We were missing a `/` in our `LOGIN_URL` setting. This was silly and made the redirect to login to OSM Auth work.

 - Another problem was that we can't get OSM to redirect back to the `set-good` URL since that needs a POST request. What I have done here is just redirect back to the changeset page, and the user will just need to mark good / bad again. This is probably optimum for now.

cc @amishas157 @geohacker 