### PR TITLE
WIP: Upgrade osmcha to use the ml changeset classifier

### DIFF
--- a/osmchadjango/changeset/tasks.py
+++ b/osmchadjango/changeset/tasks.py
@@ -27,7 +27,11 @@ def create_changeset(changeset_id):
 
     ch_dict['score'] = ch_dict['changeset_score']
     ch_dict.pop('suspicion_reasons')
-    # ch_dict.pop('user_details')
+
+    # NOTE: Added temporarily to debug
+    if 'user_details' in ch_dict:
+        ch_dict.pop('user_details')
+
     ch_dict.pop('user_score')
     ch_dict.pop('changeset_score')
     ch_dict.pop('user_score_details')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ celery==3.1.19
 
 # Your custom requirements go here
 PyYAML==3.11
-git+https://github.com/mapbox/osmcha.git@e4d0a328248d843d32008ad36651c80a04c79eef
+git+https://github.com/mapbox/osmcha.git@2337258753710e6017e7513bc47f28b3fc2d79e1
 django-filter==0.12.0
 git+https://github.com/batpad/django-query-parameters.git@fix-unicode
 django-queryset-csv==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ celery==3.1.19
 
 # Your custom requirements go here
 PyYAML==3.11
-git+https://github.com/mapbox/osmcha.git@2e2f0fe3bc132483971439cb468cc9878dd50deb
+git+https://github.com/mapbox/osmcha.git@2453eec825318acef8b446fa5c4f7da988e1288c
 django-filter==0.12.0
 git+https://github.com/batpad/django-query-parameters.git@fix-unicode
 django-queryset-csv==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ celery==3.1.19
 
 # Your custom requirements go here
 PyYAML==3.11
-git+https://github.com/mapbox/osmcha.git@2337258753710e6017e7513bc47f28b3fc2d79e1
+git+https://github.com/mapbox/osmcha.git@2e2f0fe3bc132483971439cb468cc9878dd50deb
 django-filter==0.12.0
 git+https://github.com/batpad/django-query-parameters.git@fix-unicode
 django-queryset-csv==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ celery==3.1.19
 
 # Your custom requirements go here
 PyYAML==3.11
-git+https://github.com/mapbox/osmcha.git@e34ec98acbcafa04d5b4daaf8e2d13b11d41472d
+git+https://github.com/mapbox/osmcha.git@e4d0a328248d843d32008ad36651c80a04c79eef
 django-filter==0.12.0
 git+https://github.com/batpad/django-query-parameters.git@fix-unicode
 django-queryset-csv==1.0.0


### PR DESCRIPTION
*NOTE: Please do not deploy this branch to `production` until [autovandal](https://github.com/mapbox/autovandal/) is a public repository.*

## Objective
- [x] Upgrade `osmcha` in `osmcha-django` to use the ml changeset classifier work

## Next actions
- [x] Deploy branch to osmcha-staging
- [x] Deploy branch to osmcha-production

---

cc: @rodowi